### PR TITLE
Adding Datastore to usage guide

### DIFF
--- a/docs-content/using.html.md.erb
+++ b/docs-content/using.html.md.erb
@@ -53,6 +53,36 @@ For more information, see the [GCP Understanding Roles](https://cloud.google.com
 }
 </pre>
 
+###<a id="storage"></a>Google Cloud Datastore
+
+#### Create 
+
+Run `cf create-service google-datastore` to create a new database instance and database.
+<pre class="terminal">$ cf create-service google-datastore default mydatabase
+</pre>
+
+#### Bind
+
+Bind the `google-datastore` service to an app to create a new service account and private key.
+
+The following example creates a service account with the `datastore.user` role.
+For more information, see the [GCP Understanding Roles](https://cloud.google.com/iam/docs/understanding-roles) topic.
+
+<pre class="terminal">$ cf bind-service myapp mydatabase
+</pre>
+
+<p class="note"><strong>Note</strong>: Run <code>cf unbind-service</code> to delete the service account and key created when binding.</p>
+
+**Example Binding credentials**
+<pre>"credentials": {
+     "Email": "redacted",
+     "Name": "redacted",
+     "PrivateKeyData": "redacted",
+     "UniqueId": "redacted",
+     "dataset_id": "foobar",
+}
+</pre>
+
 ###<a id="bigquery"></a>Google BigQuery
 
 #### Create 


### PR DESCRIPTION
The docs on pivnet have gotten out of date, the OSS usage guide already includes Datastore.