### PR TITLE
Revert "Update docs for release 4.2.0"

### DIFF
--- a/docs-content/index.html.md.erb
+++ b/docs-content/index.html.md.erb
@@ -31,19 +31,19 @@ The following table provides version and version-support information about GCP S
     <th>Details</th>
     <tr>
         <td>Version</td>
-        <td>v4.2.0</td>
+        <td>v4.1.0</td>
     </tr>
     <tr>
         <td>Release date</td>
-        <td>January 15, 2019</td>
+        <td>November 5, 2018</td>
     </tr>
     <tr>
         <td>Compatible Ops Manager version(s)</td>
-        <td>v2.2.x, v2.3.x, and v2.4.x</td>
+        <td>v2.1.x, v2.2.x, and v2.3.x</td>
     </tr>
     <tr>
         <td>Compatible Pivotal Application Service (formerly known as Elastic Runtime) version(s)</td>
-        <td>v2.2.x, v2.3.x, and v2.4.x</td>
+        <td>v2.1.x, v2.2.x, and v2.3.x</td>
     </tr>
     <tr>
         <td>IaaS support</td>

--- a/docs-content/release-notes.html.md.erb
+++ b/docs-content/release-notes.html.md.erb
@@ -3,38 +3,6 @@ breadcrumb: PCF Services
 title: Release Notes
 ---
 
-### v4.2.0
-
-**Release Date:** January 15, 2019
-
-#### Security
-The broker uses a Pivotal library affected by CVE-2018-15759. Until the library is updated, it's recommended that you not run the service broker on a public network. If you must run it on a public network, make it accessible through a proxy that supports fail2ban.
-
-#### Added
-- The ability to enable/disable services based on product lifecycle tags. See #340 for context.
-- Preview support for Firestore.
-- Preview support for Dialogflow.
-- Preview support for Stackdriver Metrics.
-- Namespace support for Datastore.
-- Preview support for Dataflow.
-- Default roles for ML, BigQuery, BigTable, CloudSQL, Pub/Sub, Spanner, and Cloud Storage.
-- /docs endpoint that serves docs for your installation.
-- Preview support for Dataproc via brokerpaks.
-- Varcontext now supports casting computed HIL values.
-- New regional and multi-regional Cloud Storage plans.
-- Ability to expose JSONSchema in the service catalog by enabling the enable-catalog-schemas flag.
-
-#### Changed
-- Support links for services now point to service-specific pages where possible.
-- Feature flags are now handled through a generic toggles framework. Option labels and descriptions might change slightly in the tile.
-- Service definitions now get field-level validation to check for sanity before being registered.
-
-#### Removed
-- The examples/ directory.
-
-#### Fixed
-- Fixed machine types for PostgreSQL to use custom but keep the old names for compatibility.
-
 ### v4.1.0
 
 **Release Date:** November 5, 2018


### PR DESCRIPTION
Reverts pivotal-cf/docs-google#31 just until we decide to make the release available